### PR TITLE
기능 :: 키와 리전을 직접 입력하도록 변경

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -8,9 +8,9 @@ const Home = () => {
   const [audioUrl, setAudioUrl] = useState<string | undefined>(undefined);
   const [visemeUrl, setVisemeUrl] = useState<string | undefined>(undefined);
 
-  const handleSubmit = async (voice: string, expressStyle: string, phrase: string) => {
+  const handleSubmit = async (speechKey: string, speechRegion: string, voice: string, expressStyle: string, phrase: string) => {
     try {
-      const result = await texttospeech(voice, expressStyle, phrase);
+      const result = await texttospeech(speechKey, speechRegion, voice, expressStyle, phrase);
       if (!result) {
         throw new Error('음성 합성 실패');
       }

--- a/src/components/TextToSpeechForm.tsx
+++ b/src/components/TextToSpeechForm.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 interface TextToSpeechFormProps {
-  onSubmit: (voice: string, expressStyle: string, phrase: string) => void;
+  onSubmit: (speechKey: string, speechRegion: string, voice: string, expressStyle: string, phrase: string) => void;
 }
 
 export default function TextToSpeechForm({ onSubmit }: TextToSpeechFormProps) {
@@ -9,15 +9,19 @@ export default function TextToSpeechForm({ onSubmit }: TextToSpeechFormProps) {
     e.preventDefault();
 
     const formData = new FormData(e.target as HTMLFormElement); 
+    const speechKey = formData.get('speechKey') as string;
+    const speechRegion = formData.get('speechRegion') as string;
     const voice = formData.get('voice') as string;
     const expressStyle = formData.get('expressStyle') as string;
     const phrase = formData.get('phrase') as string;
 
-    onSubmit(voice, expressStyle, phrase);
+    onSubmit(speechKey, speechRegion, voice, expressStyle, phrase);
   }
   
   return (
     <form className="flex flex-col gap-4 w-full max-w-xl h-full" onSubmit={handleSubmit}>
+      <input type="text" name="speechKey" className="w-full p-2 border border-gray-700 focus:bg-gray-400/10 rounded-lg" placeholder="speech key" />
+      <input type="text" name="speechRegion" className="w-full p-2 border border-gray-700 focus:bg-gray-400/10 rounded-lg" placeholder="speech region" />
       <select name="voice" className="w-full px-1 py-2 border border-gray-700 rounded-lg">
         <option className="p-2 bg-white" value="en-US-JasonNeural">US: Jason</option>
         <option className="p-2 bg-white" value="en-US-CoraNeural">US: Cora</option>
@@ -35,7 +39,7 @@ export default function TextToSpeechForm({ onSubmit }: TextToSpeechFormProps) {
         <option className="p-2 bg-white" value="angry">angry</option>
         <option className="p-2 bg-white" value="depressed">depressed</option>
       </select>
-      <textarea name="phrase" placeholder="phrase" className="w-full p-2 border border-gray-700 focus:bg-gray-400/10 rounded-lg" rows={8} />
+      <textarea name="phrase" defaultValue="Hello, world!" placeholder="phrase" className="w-full p-2 border border-gray-700 focus:bg-gray-400/10 rounded-lg" rows={8} />
       <button type="submit" className="w-full p-2 border border-gray-700 hover:bg-gray-400/10 rounded-lg">Submit</button>
     </form>
   );

--- a/src/libs/texttospeech.ts
+++ b/src/libs/texttospeech.ts
@@ -2,9 +2,6 @@
 
 import { SpeechConfig, AudioConfig, SpeakerAudioDestination, SpeechSynthesizer, ResultReason, SpeechSynthesisResult } from 'microsoft-cognitiveservices-speech-sdk';
 
-const SPEECH_KEY = process.env.NEXT_PUBLIC_SPEECH_KEY!;
-const SPEECH_REGION = process.env.NEXT_PUBLIC_SPEECH_REGION!;
-
 interface TextToSpeechResult {
   audioUrl: string;
   visemeUrl: string;
@@ -17,11 +14,11 @@ interface TextToSpeechResult {
  * @param phrase 텍스트
  * @returns 음성 데이터와 시각화 데이터
  */
-const texttospeech = async (voice: string, expressStyle: string, phrase: string): Promise<TextToSpeechResult> => {
+const texttospeech = async (speechKey: string, speechRegion: string, voice: string, expressStyle: string, phrase: string): Promise<TextToSpeechResult> => {
   return new Promise((resolve, reject) => {
     // Synthesizer 객체 생성
     const audioDestination = new SpeakerAudioDestination();    
-    const speechConfig = SpeechConfig.fromSubscription(SPEECH_KEY, SPEECH_REGION);
+    const speechConfig = SpeechConfig.fromSubscription(speechKey, speechRegion);
     const audioConfig = AudioConfig.fromSpeakerOutput(audioDestination);
     const synthesizer = new SpeechSynthesizer(speechConfig, audioConfig);
 


### PR DESCRIPTION
## Sourcery 요약

본 풀 리퀘스트는 사용자가 환경 변수에 의존하는 대신 음성 키와 지역을 직접 입력할 수 있도록 텍스트 음성 변환 기능을 수정합니다. 이 변경으로 애플리케이션의 유연성과 사용성이 향상됩니다.

새로운 기능:
- 사용자가 텍스트 음성 변환 기능을 위해 음성 키와 지역을 직접 입력할 수 있습니다.

개선 사항:
- TextToSpeechForm 컴포넌트를 업데이트하여 음성 키와 지역을 위한 입력 필드를 포함합니다.
- texttospeech 함수를 업데이트하여 음성 키와 지역을 파라미터로 받습니다.

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

This pull request modifies the text-to-speech functionality to allow users to directly input their speech key and region, instead of relying on environment variables. This change enhances the flexibility and usability of the application.

New Features:
- Allows users to input their own speech key and region for text-to-speech functionality.

Enhancements:
- Updates the TextToSpeechForm component to include input fields for speech key and region.
- Updates the texttospeech function to accept speech key and region as parameters.

</details>